### PR TITLE
Decrease job timeout

### DIFF
--- a/helm/etcd-backup-chart/templates/cronjob.yaml
+++ b/helm/etcd-backup-chart/templates/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
   jobTemplate:
     spec:
       # Job timeout
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 120
       template:
         spec:
           # Container creates etcd backups.


### PR DESCRIPTION
2 minutes (new value) should be enough to create and
upload backup. But also this will help in case fails,
with old value 600sec we had ~200 containers in Error
state after failing job execution.

https://github.com/giantswarm/giantswarm/issues/1787