### PR TITLE
do-not-backup-test-installations

### DIFF
--- a/helm/etcd-backup-chart/templates/cronjob.yaml
+++ b/helm/etcd-backup-chart/templates/cronjob.yaml
@@ -32,7 +32,9 @@ spec:
           - name: etcd-backup
             image: quay.io/giantswarm/etcd-backup:[[ .SHA ]]
             args:
-            - -guest-backup=true
+            # backup guest clusters only on production instalations
+            # testing installation can have many broken guest clusters
+            - -guest-backup={{ not .Values.Installation.V1.Infra.TestingEnvironment }}
             - -prefix={{ .Values.Installation.V1.Infra.EtcdBackup.ClusterPrefix }}
             - -provider={{ .Values.Installation.V1.Provider.Kind }}
             - -etcd-v2-datadir=/var/lib/etcd


### PR DESCRIPTION
turn off guest cluster backup for testing installation

Reason for it is that we often have broken clusters there and this will create alerts.