### PR TITLE
Don´t store any backup job failed

### DIFF
--- a/helm/etcd-backup-chart/templates/cronjob.yaml
+++ b/helm/etcd-backup-chart/templates/cronjob.yaml
@@ -7,7 +7,7 @@ spec:
   # Run everyday at 3AM.
   schedule: "{{ .Values.Installation.V1.Infra.EtcdBackup.CronSchedule }}"
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
       # Job timeout

--- a/helm/etcd-backup-chart/templates/cronjob.yaml
+++ b/helm/etcd-backup-chart/templates/cronjob.yaml
@@ -7,11 +7,12 @@ spec:
   # Run everyday at 3AM.
   schedule: "{{ .Values.Installation.V1.Infra.EtcdBackup.CronSchedule }}"
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
       # Job timeout
       activeDeadlineSeconds: 300
+      ttlSecondsAfterFinished: 79200
       template:
         spec:
           tolerations:


### PR DESCRIPTION
References  https://github.com/giantswarm/giantswarm/issues/5222

To remove alerts for etcd backups failed jobs.

The behaviour will be the following:
- A job will start a pod defined in the cronjob for etcd backup.
If the pod returns an error it will retry the same operation 6 times(default backoffLimit), then if the last pod had an error status too, job and pods involved will be removed and don't kept in kubectl get jobs command.

You can still see that there is a problem checking the age of the last completed job.

We need to keep an eye on TTL if it hits the stable version
[https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)

