### PR TITLE
Add TTL After finished feature

### DIFF
--- a/helm/etcd-backup-chart/templates/cronjob.yaml
+++ b/helm/etcd-backup-chart/templates/cronjob.yaml
@@ -11,6 +11,7 @@ spec:
   jobTemplate:
     spec:
       # Job timeout
+      TTLAfterFinished: 86400
       activeDeadlineSeconds: 600
       template:
         spec:

--- a/helm/etcd-backup-chart/templates/cronjob.yaml
+++ b/helm/etcd-backup-chart/templates/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
   jobTemplate:
     spec:
       # Job timeout
-      TTLAfterFinished: 86400
+      TTLAfterFinished: 21600
       activeDeadlineSeconds: 600
       template:
         spec:


### PR DESCRIPTION
 - After adding feature gate `TTLAfterFinished=true`in all our API, we can now create cronjobs with a ttlSecondsAfterFinished  feature which removes a job after x seconds in our backup.

Now our backups run every 6h, if there is a failed backup we will be alerted for this failed backup during 6h. Reached that point the failed job will be removed so we won´t receive this alarm but a new backup will be scheduled and if it fails we will get this new one.