### PR TITLE
Increase etcdctl timeouts

### DIFF
--- a/etcd/backup_v2.go
+++ b/etcd/backup_v2.go
@@ -31,11 +31,11 @@ func (b *EtcdBackupV2) Create() error {
 	// Create a etcd.
 	etcdctlEnvs := []string{}
 	etcdctlArgs := []string{
+		"--timeout", dialTimeout,
+		"--total-timeout", totalTimeout,
 		"backup",
 		"--data-dir", b.Datadir,
 		"--backup-dir", filepath.Join(b.TmpDir, b.Filename),
-		"--timeout", dialTimeout,
-		"--total-timeout", totalTimeout,
 	}
 
 	_, err := execCmd(etcdctlCmd, etcdctlArgs, etcdctlEnvs, b.Logger)

--- a/etcd/backup_v2.go
+++ b/etcd/backup_v2.go
@@ -34,6 +34,8 @@ func (b *EtcdBackupV2) Create() error {
 		"backup",
 		"--data-dir", b.Datadir,
 		"--backup-dir", filepath.Join(b.TmpDir, b.Filename),
+		"--timeout", dialTimeout,
+		"--total-timeout", totalTimeout,
 	}
 
 	_, err := execCmd(etcdctlCmd, etcdctlArgs, etcdctlEnvs, b.Logger)

--- a/etcd/backup_v3.go
+++ b/etcd/backup_v3.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/giantswarm/etcd-backup/config"
@@ -31,7 +32,10 @@ func (b *EtcdBackupV3) Create() error {
 	// Full path to file.
 	fpath := filepath.Join(b.TmpDir, b.Filename)
 
-	etcdctlEnvs := []string{"ETCDCTL_API=3"}
+	etcdctlEnvs := []string{
+		"ETCDCTL_API=3",
+		fmt.Sprintf("ETCDCTL_DIAL_TIMEOUT=%s", dialTimeout),
+	}
 	etcdctlArgs := []string{
 		"snapshot",
 		"save",

--- a/etcd/util.go
+++ b/etcd/util.go
@@ -25,6 +25,10 @@ const (
 	tgzExt     = ".tar.gz"
 	encExt     = ".enc"
 	dbExt      = ".db"
+
+	// Timeouts for etcdctl
+	dialTimeout  = "5s"
+	totalTimeout = "15s"
 )
 
 // Outputs timestamp.


### PR DESCRIPTION
Increase default dial & total timeouts in order go cope with busy clusters. On
asgard there's a pattern that etcd backups fail during day but succeed during
night. Try to increase timeouts in order to see if it's only increased latency
due to traffic.