### PR TITLE
Added mandatory provider field and S3 region

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ docker run --rm \
     -e ETCDBACKUP_PASSPHRASE=ZZZ \
     -v /var/lib/etcd:/var/lib/etcd \
     quay.io/giantswarm/etcd-backup \
+    -provider aws \
+    -aws-s3-region eu-west-1 \  
     -aws-s3-bucket bucket \
     -prefix cluster1 \
     -etcd-v3-endpoints http://172.17.0.1:2379 \


### PR DESCRIPTION
In `Main.go` file there's this requirement: 

`flag.StringVar(&f.Provider, "provider", "", "[mandatory] provider (aws, azure or kvm)")`

Which isn't present in `docker run` command alongside with S3 Region which altogether may lead to unsuccessful backups due to wrong defaults. 

